### PR TITLE
/define improvements and what would you know, an escape_md helper

### DIFF
--- a/commands/define_command.rb
+++ b/commands/define_command.rb
@@ -1,10 +1,10 @@
-require_relative '../lib/escape'
+require_relative '../lib/helpers/escape'
 
 module Commands
   class DefineCommand
-    include Helpers
-
     class << self
+      include Helpers
+
       def name
         :define
       end
@@ -46,8 +46,8 @@ module Commands
           end
 
           defs.map { |w|
-            text = Helpers.escape_md w["text"]
-            pos = Helpers.escape_md w["partOfSpeech"]
+            text = escape_md w["text"]
+            pos = escape_md w["partOfSpeech"]
 
             "*#{pos}*. #{text}"
           }.join "\n"

--- a/commands/define_command.rb
+++ b/commands/define_command.rb
@@ -1,5 +1,9 @@
+require_relative '../lib/escape'
+
 module Commands
   class DefineCommand
+    include Helpers
+
     class << self
       def name
         :define
@@ -20,9 +24,9 @@ module Commands
 
         wordnik_url = "https://api.wordnik.com/v4/word.json/#{term}/definitions"
         wordnik_headers = {
-            limit: 1,
+            limit: 5,
             includeRelated: true,
-            useCanonical: false,
+            useCanonical: true,
             includeTags: false,
             api_key: ENV['wordnik_key']
         }
@@ -31,15 +35,22 @@ module Commands
           body = JSON.parse RestClient.get(wordnik_url, params: wordnik_headers)
           p body
 
-          if body.first
-            if body.first['text']
-              body.first['text']
-            else
-              "Word found, but no definition provided"
-            end
-          else
-            "No results found for #{term}"
+          unless body.first
+            return "No results found for #{term}"
           end
+
+          defs = body.filter { |w| w["text"] }
+          unless defs.first
+            word_url = body.first["wordnikUrl"]
+            return "Word found, but no definition provided. Try visiting #{word_url}."
+          end
+
+          defs.map { |w|
+            text = Helpers.escape_md w["text"]
+            pos = Helpers.escape_md w["partOfSpeech"]
+
+            "*#{pos}*. #{text}"
+          }.join "\n"
         rescue RestClient::NotFound => e
           "Word not found"
         end

--- a/lib/escape.rb
+++ b/lib/escape.rb
@@ -1,0 +1,7 @@
+module Helpers
+  def Helpers.escape_md(text)
+    # Replace all Discord-flaored markdown special characters, which are not
+    # themselves escaped.
+    text.gsub(/(?<!\\)([`~*_|>])/) { "\\" + $1 }
+  end
+end

--- a/lib/helpers/escape.rb
+++ b/lib/helpers/escape.rb
@@ -1,5 +1,5 @@
 module Helpers
-  def Helpers.escape_md(text)
+  def escape_md(text)
     # Replace all Discord-flaored markdown special characters, which are not
     # themselves escaped.
     text.gsub(/(?<!\\)([`~*_|>])/) { "\\" + $1 }

--- a/test/escape_markdown_test.rb
+++ b/test/escape_markdown_test.rb
@@ -2,7 +2,7 @@ require 'simplecov'
 SimpleCov.start
 
 require 'test/unit/rr'
-require_relative '../lib/escape'
+require_relative '../lib/helpers/escape'
 
 class EscapeMarkdownTest < Test::Unit::TestCase
   include Helpers
@@ -11,7 +11,7 @@ class EscapeMarkdownTest < Test::Unit::TestCase
     source = 'hello * world \\* howdy'
     expected = 'hello \\* world \\* howdy'
 
-    assert_equal(expected, Helpers::escape_md(source))
+    assert_equal(expected, escape_md(source))
   end
 
   def test_it_whatever()
@@ -20,6 +20,6 @@ class EscapeMarkdownTest < Test::Unit::TestCase
     source = '`_Behold!_`\n||___~~***```js\n`use strict`;\nrequire(\'discord.js\');```***~~___||'
     expected = '\\`\\_Behold!\\_\\`\n\\|\\|\\_\\_\\_\\~\\~\\*\\*\\*\\`\\`\\`js\n\\`use strict\\`;\nrequire(\'discord.js\');\\`\\`\\`\\*\\*\\*\\~\\~\\_\\_\\_\\|\\|'
 
-    assert_equal(expected, Helpers::escape_md(source))
+    assert_equal(expected, escape_md(source))
   end
 end

--- a/test/escape_markdown_test.rb
+++ b/test/escape_markdown_test.rb
@@ -1,0 +1,25 @@
+require 'simplecov'
+SimpleCov.start
+
+require 'test/unit/rr'
+require_relative '../lib/escape'
+
+class EscapeMarkdownTest < Test::Unit::TestCase
+  include Helpers
+
+  def test_it_escapes_asterisks()
+    source = 'hello * world \\* howdy'
+    expected = 'hello \\* world \\* howdy'
+
+    assert_equal(expected, Helpers::escape_md(source))
+  end
+
+  def test_it_whatever()
+    # Shamelessly stolen from discord.js
+    # https://github.com/discordjs/discord.js/blob/651ff81bd522c03b5c9724a3a8c14eeb88dcd6b9/test/escapeMarkdown.test.js#L6
+    source = '`_Behold!_`\n||___~~***```js\n`use strict`;\nrequire(\'discord.js\');```***~~___||'
+    expected = '\\`\\_Behold!\\_\\`\n\\|\\|\\_\\_\\_\\~\\~\\*\\*\\*\\`\\`\\`js\n\\`use strict\\`;\nrequire(\'discord.js\');\\`\\`\\`\\*\\*\\*\\~\\~\\_\\_\\_\\|\\|'
+
+    assert_equal(expected, Helpers::escape_md(source))
+  end
+end


### PR DESCRIPTION
Bonus fun: Check the commit message on the `/define` improvements for why some words returned "no definition found".